### PR TITLE
ETPLT-8: Setup Travis CI and Checkstyle with Google Code Style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk: oraclejdk8
+
+script:
+  - mvn test --batch-mode
+  - mvn checkstyle:check --batch-mode --fail-never

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>esup-twitter</artifactId>
     <packaging>war</packaging>
     <version>0.15-SNAPSHOT</version>
-    
+
     <name>EsupTwitter</name>
     <description>EsupTwitter : display timelines from twitter.com</description>
     <url>http://www.jasig.org</url>
@@ -172,7 +172,7 @@
 		<artifactId>spring-social-twitter</artifactId>
 		<version>1.1.0.RELEASE</version>
 	</dependency>
-	
+
 	<dependency>
 		<groupId>net.sf.ehcache</groupId>
 		<artifactId>ehcache-core</artifactId>
@@ -199,9 +199,9 @@
 		<artifactId>json</artifactId>
 		<version>20090211</version>
 	</dependency>
-            
+
     </dependencies>
-    
+
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -286,4 +286,17 @@
             </build>
         </profile>
     </profiles>
+
+    <reporting>
+       <plugins>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-checkstyle-plugin</artifactId>
+               <version>2.17</version>
+               <configuration>
+                   <configLocation>google_checks.xml</configLocation>
+               </configuration>
+           </plugin>
+       </plugins>
+   </reporting>
 </project>


### PR DESCRIPTION
[ETPLT-8](https://issues.jasig.org/browse/ETPLT-8)

Setup Travis CI build to include Checkstyle configured to use the Google Code Style.

[Travis CI webhook may need to be enabled for repository.](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A)