### PR TITLE
ETPLT-12: Add Findbugs to Maven reporters and address recommendations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,11 @@
                    <configLocation>google_checks.xml</configLocation>
                </configuration>
            </plugin>
+           <plugin>
+               <groupId>org.codehaus.mojo</groupId>
+               <artifactId>findbugs-maven-plugin</artifactId>
+               <version>3.0.5-SNAPSHOT</version>
+           </plugin>
        </plugins>
    </reporting>
 </project>

--- a/src/main/java/org/esupportail/twitter/services/CachingTwitterService.java
+++ b/src/main/java/org/esupportail/twitter/services/CachingTwitterService.java
@@ -36,9 +36,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CachingTwitterService implements TwitterService {
-
-	private Logger log = Logger.getLogger(this.getClass());
-	
 	@Autowired
     private OAuthTwitterConfig oAuthTwitterConfig;
 	
@@ -55,7 +52,7 @@ public class CachingTwitterService implements TwitterService {
 			.apiSecret(oAuthTwitterConfig.getConsumerSecret())
 			.build();
 		} else {
-			new Exception("You have to setup twitterConfig.xml and register your EsupTwitter on https://dev.twitter.com/apps");
+			throw new Exception("You have to setup twitterConfig.xml and register your EsupTwitter on https://dev.twitter.com/apps");
 		}
 	}
 	

--- a/src/main/java/org/esupportail/twitter/services/OAuthTwitterApplicationOnlyService.java
+++ b/src/main/java/org/esupportail/twitter/services/OAuthTwitterApplicationOnlyService.java
@@ -75,7 +75,7 @@ public class OAuthTwitterApplicationOnlyService implements InitializingBean {
     		return new String(encodedBytes);  
     	}
     	catch (UnsupportedEncodingException e) {
-    		return new String();
+    		return "";
     	}
     }
     
@@ -125,33 +125,44 @@ public class OAuthTwitterApplicationOnlyService implements InitializingBean {
     
     
  // Writes a request to a connection
-    private static boolean writeRequest(HttpURLConnection connection, String textBody) {
+    private static boolean writeRequest(HttpURLConnection connection, String textBody) throws IOException {
+		BufferedWriter wr = null;
     	try {
-    		BufferedWriter wr = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
+    		wr = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
     		wr.write(textBody);
     		wr.flush();
-    		wr.close();
     			
     		return true;
     	}
     	catch (IOException e) { 
     		return false; 
     	}
-    }
+    	finally {
+    		if (wr != null) {
+    			wr.close();
+			}
+		}
+	}
     	
     	
     // Reads a response for a given connection and returns it as a string.
-    private static String readResponse(HttpURLConnection connection) {
+    private static String readResponse(HttpURLConnection connection) throws IOException {
+		BufferedReader br = null;
     	try {
     		StringBuilder str = new StringBuilder();
     			
-    		BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+    		br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
     		String line = "";
     		while((line = br.readLine()) != null) {
     			str.append(line + System.getProperty("line.separator"));
     		}
     		return str.toString();
     	}
-    	catch (IOException e) { return new String(); }
-    }
+    	catch (IOException e) { return ""; }
+    	finally {
+    		if (br != null) {
+    			br.close();
+			}
+		}
+	}
 }

--- a/src/main/java/org/esupportail/twitter/web/MinimizedStateHandlerInterceptor.java
+++ b/src/main/java/org/esupportail/twitter/web/MinimizedStateHandlerInterceptor.java
@@ -77,7 +77,7 @@ public class MinimizedStateHandlerInterceptor  extends HandlerInterceptorAdapter
             String twitterUserToken = prefs.getValue(PREF_TWITTER_USER_TOKEN, null);
             String twitterUserSecret = prefs.getValue(PREF_TWITTER_USER_SECRET, null);
             
-            int tweetsNumber = (new Integer(prefs.getValue(PREF_TWITTER_TWEETS_NUMBER, "-1"))).intValue();  
+            int tweetsNumber = Integer.parseInt(prefs.getValue(PREF_TWITTER_TWEETS_NUMBER, "-1"));
 
             // get username timeline with oAuth authentication
             log.debug("twitterUserToken:" + twitterUserToken);

--- a/src/main/java/org/esupportail/twitter/web/TwitterController.java
+++ b/src/main/java/org/esupportail/twitter/web/TwitterController.java
@@ -67,7 +67,7 @@ public class TwitterController {
     	String twitterUserToken = prefs.getValue(PREF_TWITTER_USER_TOKEN, null);
     	String twitterUserSecret = prefs.getValue(PREF_TWITTER_USER_SECRET, null);	
     	
-    	int tweetsNumber = (new Integer(prefs.getValue(PREF_TWITTER_TWEETS_NUMBER, "-1"))).intValue();	
+    	int tweetsNumber = Integer.parseInt(prefs.getValue(PREF_TWITTER_TWEETS_NUMBER, "-1"));
 
     	// get username timeline with oAuth authentication
     	log.debug("twitterUserToken:" + twitterUserToken);
@@ -182,7 +182,7 @@ public class TwitterController {
         if (StringUtils.hasText(twitterTweetsNumber) && StringUtils.hasLength(twitterTweetsNumber)) {
         	int twitterTweetsNumberInt = -1;
         	try {
-        		twitterTweetsNumberInt = (new Integer(twitterTweetsNumber)).intValue();
+        		twitterTweetsNumberInt = Integer.parseInt(twitterTweetsNumber);
         	} catch (Exception ex) {
         	}
         	if(twitterTweetsNumberInt > 0) {


### PR DESCRIPTION
<https://issues.jasig.org/browse/ETPLT-12>

Adds findbugs to maven reporting tools.
report can be viewed in the findbug GUI by running.

``` sh
mvn install findbugs:findbugs findbugs:gui
```

Below is the formatted output from before any changes were made.

``` log
H C RV: new Exception(String) not thrown in org.esupportail.twitter.services.CachingTwitterService.afterPropertiesSet()  At CachingTwitterService.java:[line 58]
M P UrF: Unread field: org.esupportail.twitter.services.CachingTwitterService.log  At CachingTwitterService.java:[line 40]
H I Dm: Found reliance on default encoding in org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.encodeKeys(String, String): new String(byte[])  At OAuthTwitterApplicationOnlyService.java:[line 75]
H I Dm: Found reliance on default encoding in org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.encodeKeys(String, String): String.getBytes()  At OAuthTwitterApplicationOnlyService.java:[line 74]
H I Dm: Found reliance on default encoding in org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.readResponse(HttpURLConnection): new java.io.InputStreamReader(InputStream)  At OAuthTwitterApplicationOnlyService.java:[line 148]
H I Dm: Found reliance on default encoding in org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.writeRequest(HttpURLConnection, String): new java.io.OutputStreamWriter(OutputStream)  At OAuthTwitterApplicationOnlyService.java:[line 130]
M P Dm: org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.encodeKeys(String, String) invokes inefficient new String() constructor  At OAuthTwitterApplicationOnlyService.java:[line 78]
M P Dm: org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.readResponse(HttpURLConnection) invokes inefficient new String() constructor  At OAuthTwitterApplicationOnlyService.java:[line 155]
M B OS: org.esupportail.twitter.services.OAuthTwitterApplicationOnlyService.readResponse(HttpURLConnection) may fail to close stream  At OAuthTwitterApplicationOnlyService.java:[line 148]
H P Bx: Boxing/unboxing to parse a primitive org.esupportail.twitter.web.MinimizedStateHandlerInterceptor.preHandleRender(RenderRequest, RenderResponse, Object)  At MinimizedStateHandlerInterceptor.java:[line 80]
M P Bx: org.esupportail.twitter.web.MinimizedStateHandlerInterceptor.preHandleRender(RenderRequest, RenderResponse, Object) invokes inefficient new Integer(String) constructor; use Integer.valueOf(String) instead  At MinimizedStateHandlerInterceptor.java:[line 80]
H P Bx: Boxing/unboxing to parse a primitive org.esupportail.twitter.web.TwitterController.renderView(RenderRequest, RenderResponse)  At TwitterController.java:[line 70]
H P Bx: Boxing/unboxing to parse a primitive org.esupportail.twitter.web.TwitterController.setTwitterTweetsNumber(String, ActionRequest, ActionResponse)  At TwitterController.java:[line 185]
M P Bx: org.esupportail.twitter.web.TwitterController.renderView(RenderRequest, RenderResponse) invokes inefficient new Integer(String) constructor; use Integer.valueOf(String) instead  At TwitterController.java:[line 70]
M P Bx: org.esupportail.twitter.web.TwitterController.setTwitterTweetsNumber(String, ActionRequest, ActionResponse) invokes inefficient new Integer(String) constructor; use Integer.valueOf(String) instead  At TwitterController.java:[line 185]
```